### PR TITLE
Avoided the use of arguments.callee in the sleep function

### DIFF
--- a/sleep-async.js
+++ b/sleep-async.js
@@ -2,13 +2,13 @@ module.exports = exports = function(){
 
   function sleep(timeout, condition, interval, done){
     var startTimeInMilisecond = new Date().getTime();
-    setTimeout(function(){
+    setTimeout(function repeater(){
       var totalTimeHasExpiredOrConditionIsTrue = ((startTimeInMilisecond + timeout) < (new Date().getTime())) ||
         (condition && typeof(condition) === 'function' &&  condition());
       if(totalTimeHasExpiredOrConditionIsTrue){
         done();
       } else {
-        setTimeout(arguments.callee, interval);
+        setTimeout(repeater, interval);
       }
     }, interval);
   }


### PR DESCRIPTION
# Renamed anonymous function to **repeater**.

Modified the original code to name this function so se can **avoid argumants.callee**
See: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
for Deprecation info (in strict mode)
